### PR TITLE
fix: change workflows #36

### DIFF
--- a/.github/workflows/push-main.yaml
+++ b/.github/workflows/push-main.yaml
@@ -1,7 +1,7 @@
 ---
 name: push main
 on:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/push-main.yaml
+++ b/.github/workflows/push-main.yaml
@@ -1,12 +1,9 @@
 ---
-name: pr
+name: push main
 on:
   pull_request:
-    types:
-      - edited
-      - opened
-      - reopened
-      - synchronize
+    branches:
+      - main
 
 jobs:
   golangci:
@@ -26,13 +23,7 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 # v2.27.1
         with:
-          # Generates a SARIF file without crashing the build on findings
-          args: '-no-fail -fmt sarif -out results.sarif ./...'
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
-        with:
-          sarif_file: results.sarif
+          args: ./...
   e2e-test:
     runs-on: ubuntu-latest
     permissions:
@@ -111,7 +102,7 @@ jobs:
           context: .
           file: ./Dockerfiles/dvorah/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: false
+          push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           annotations: ${{ steps.docker_meta.outputs.annotations }}
@@ -119,3 +110,15 @@ jobs:
           sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Sign and verify the images with GitHub OIDC Token
+        env:
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          TAGS: ${{ steps.docker_meta.outputs.tags }}
+        run: |
+          IMAGE_NAME="ghcr.io/${{ github.repository }}"
+          cosign sign --yes "${IMAGE_NAME}@${DIGEST}"
+          
+          cosign verify "${IMAGE_NAME}@${DIGEST}" \
+          --certificate-identity-regexp="^https://github.com/${{ github.repository }}/.github/workflows/pr.yaml@refs/pull/.*/merge$" \
+          --certificate-oidc-issuer=https://token.actions.githubusercontent.com

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,6 +2,8 @@ name: push
 
 on:
   push:
+    branches:
+      - "!main"
 
 jobs:
   golangci:
@@ -22,13 +24,7 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 # v2.27.1
         with:
-          # Generates a SARIF file without crashing the build on findings
-          args: '-no-fail -fmt sarif -out results.sarif ./...'
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
-        with:
-          sarif_file: results.sarif
+          args: ./...
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,8 +2,8 @@ name: push
 
 on:
   push:
-    branches:
-      - "!main"
+    branches-ignore:
+      - "main"
 
 jobs:
   golangci:


### PR DESCRIPTION
- **fix: move gosec to pr only and split push workflows #36**
- **fix: move gosec to pr only and split push workflows #36**

## 🐝 Pull Request Description

### 🎯 Type of Change
- [ ] 🚀 Feature (new functionality)
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Refactor (code improvement without functional changes)
- [ ] 📝 Documentation update
- [ ] 🛡️ Security enhancement

### 🔍 Related Issue
Fixes #36 (issue number)

---

## 🛠️ Proposed Changes
- change workflows organization
- remove upload report to pr workflow only

## 🛡️ Security Impact
- none

---

## ✅ Checklist
- [ ] I have followed the **"Precision Scalpel"** philosophy (keeping the change focused and lightweight).
- [ ] I have performed a self-review of my code.
- [ ] I have run `task lint` and resolved any findings.
- [ ] I have run `task sec` (gosec) and resolved any security findings.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have updated the documentation (if applicable).
- [ ] My changes generate no new warnings in the build process.

---

## 📸 Screenshots / Logs (Optional)
